### PR TITLE
add: filter function to filter hopefuel id lists with Name and Email

### DIFF
--- a/src/app/hopefuelidlist/page.js
+++ b/src/app/hopefuelidlist/page.js
@@ -1,11 +1,21 @@
 "use client";
 
-import { Box, Divider, TextField } from "@mui/material";
-import React from "react";
+import { Box, Divider, TextField, Typography } from "@mui/material";
+import React, { useMemo, useState } from "react";
 import HopeFuelIDListItem from "./components/HopeFuelIDListItem";
 import { HOPEFUEL_ID_LISTS } from "../variables/const";
 
 const HopeFuelIdListPage = () => {
+  const [searchText, setSearchText] = useState("");
+
+  const filteredData = useMemo(() => {
+    return HOPEFUEL_ID_LISTS.filter(
+      (item) =>
+        item.Name.toLowerCase().includes(searchText.toLowerCase()) ||
+        item.Email.toLowerCase().includes(searchText.toLowerCase())
+    );
+  }, [searchText]);
+
   return (
     <>
       <Box
@@ -26,6 +36,8 @@ const HopeFuelIdListPage = () => {
           fullWidth
           variant="standard"
           placeholder="Search..."
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
           InputProps={{
             disableUnderline: true,
           }}
@@ -38,7 +50,29 @@ const HopeFuelIdListPage = () => {
           borderColor: "#CBD5E1",
         }}
       />
-      <HopeFuelIDListItem data={HOPEFUEL_ID_LISTS} />
+      {filteredData.length > 0 ? (
+        <>
+          <HopeFuelIDListItem data={filteredData} />
+        </>
+      ) : (
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
+          <Typography
+            sx={{
+              color: "#334155",
+              fontSize: "20px",
+              fontWeight: 400,
+              lineHeight: "28px",
+            }}
+          >
+            No Result Found
+          </Typography>
+        </Box>
+      )}
     </>
   );
 };


### PR DESCRIPTION
@kaungphyowai I added filter function to filter hopefuel id lists with name and email. The ticket no. is #130.
![Screenshot from 2025-02-05 17-30-59](https://github.com/user-attachments/assets/18df9616-5aac-4a9c-9c8c-c51cae17251a)
![Screenshot from 2025-02-05 17-32-09](https://github.com/user-attachments/assets/5385e3d9-b188-4338-b6ac-2da81644f29b)
