### PR TITLE
chore: fix the migration naming in generated sql

### DIFF
--- a/prisma/migrations/20250421045719_add_fk_in_customer_to_country/migration.sql
+++ b/prisma/migrations/20250421045719_add_fk_in_customer_to_country/migration.sql
@@ -5,7 +5,7 @@
 
 */
 -- AlterTable
-ALTER TABLE `customer` MODIFY `UserCountry` INTEGER NULL;
+ALTER TABLE `Customer` MODIFY `UserCountry` INTEGER NULL;
 
 -- CreateIndex
 CREATE INDEX `BaseCountryID` ON `Customer`(`UserCountry`);

--- a/prisma/migrations/init/migration.sql
+++ b/prisma/migrations/init/migration.sql
@@ -32,12 +32,13 @@ CREATE TABLE `Customer` (
     `Email` VARCHAR(255) NULL,
     `ManyChatId` VARCHAR(255) NULL,
     `ExpireDate` DATE NULL,
-    `UserCountry` VARCHAR(255) NULL,
+    `UserCountry` INTEGER NULL,
     `ContactLink` VARCHAR(255) NULL,
     `AgentId` INTEGER NULL,
     `CardID` INTEGER NULL,
 
     INDEX `AgentId`(`AgentId`),
+    INDEX `BaseCountryID`(`UserCountry`),
     PRIMARY KEY (`CustomerId`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
@@ -118,10 +119,10 @@ CREATE TABLE `Fundraiser_AcceptedCurrencies` (
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
-CREATE TABLE `fundraiser_contactlinks` (
+CREATE TABLE `Fundraiser_Contactlinks` (
     `ContactID` INTEGER NOT NULL AUTO_INCREMENT,
     `FundraiserID` INTEGER NULL,
-    `Platform` INTEGER NULL,
+    `PlatformID` INTEGER NULL,
     `ContactURL` VARCHAR(255) NOT NULL,
 
     INDEX `FundraiserID`(`FundraiserID`),
@@ -257,6 +258,9 @@ ALTER TABLE `Agent` ADD CONSTRAINT `agent_ibfk_1` FOREIGN KEY (`UserRoleId`) REF
 ALTER TABLE `Customer` ADD CONSTRAINT `customer_ibfk_1` FOREIGN KEY (`AgentId`) REFERENCES `Agent`(`AgentId`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 -- AddForeignKey
+ALTER TABLE `Customer` ADD CONSTRAINT `BaseCountryID` FOREIGN KEY (`UserCountry`) REFERENCES `BaseCountry`(`BaseCountryID`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE `CustomerAuditLogs` ADD CONSTRAINT `fk_agent` FOREIGN KEY (`AgentId`) REFERENCES `Agent`(`AgentId`) ON DELETE CASCADE ON UPDATE RESTRICT;
 
 -- AddForeignKey
@@ -287,7 +291,7 @@ ALTER TABLE `Fundraiser_AcceptedCurrencies` ADD CONSTRAINT `fundraiser_acceptedc
 ALTER TABLE `Fundraiser_AcceptedCurrencies` ADD CONSTRAINT `fundraiser_acceptedcurrencies_ibfk_2` FOREIGN KEY (`CurrencyID`) REFERENCES `Currency`(`CurrencyId`) ON DELETE CASCADE ON UPDATE RESTRICT;
 
 -- AddForeignKey
-ALTER TABLE `fundraiser_contactlinks` ADD CONSTRAINT `fundraiser_contactlinks_ibfk_1` FOREIGN KEY (`FundraiserID`) REFERENCES `Fundraiser`(`FundraiserID`) ON DELETE CASCADE ON UPDATE RESTRICT;
+ALTER TABLE `Fundraiser_Contactlinks` ADD CONSTRAINT `fundraiser_contactlinks_ibfk_1` FOREIGN KEY (`FundraiserID`) REFERENCES `Fundraiser`(`FundraiserID`) ON DELETE CASCADE ON UPDATE RESTRICT;
 
 -- AddForeignKey
 ALTER TABLE `ManyChat` ADD CONSTRAINT `fk_manychat_customer` FOREIGN KEY (`CustomerId`) REFERENCES `Customer`(`CustomerId`) ON DELETE CASCADE ON UPDATE RESTRICT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,7 +119,7 @@ model Fundraiser {
   FundraiserCentralID           Int?
   BaseCountry                   BaseCountry?                    @relation(fields: [BaseCountryID], references: [BaseCountryID], onUpdate: Restrict, map: "fundraiser_ibfk_1")
   Fundraiser_AcceptedCurrencies Fundraiser_AcceptedCurrencies[]
-  fundraiser_contactlinks       fundraiser_contactlinks[]
+  fundraiser_contactlinks       Fundraiser_Contactlinks[]
 
   @@index([BaseCountryID], map: "BaseCountryID")
 }
@@ -135,10 +135,10 @@ model Fundraiser_AcceptedCurrencies {
   @@index([FundraiserID], map: "FundraiserID")
 }
 
-model fundraiser_contactlinks {
+model Fundraiser_Contactlinks {
   ContactID    Int         @id @default(autoincrement())
   FundraiserID Int?
-  Platform     Int?
+  PlatformID   Int?
   ContactURL   String      @db.VarChar(255)
   Fundraiser   Fundraiser? @relation(fields: [FundraiserID], references: [FundraiserID], onDelete: Cascade, onUpdate: Restrict, map: "fundraiser_contactlinks_ibfk_1")
 


### PR DESCRIPTION
I fixed the naming from lowercase to uppercase in generated sql by prisma