### PR TITLE
add: payment checker kpis api

### DIFF
--- a/src/app/api/transactions/checker-kpis/route.js
+++ b/src/app/api/transactions/checker-kpis/route.js
@@ -1,0 +1,138 @@
+import { NextResponse } from "next/server";
+import prisma from "../../../utilites/prisma";
+import dayjs from "dayjs";
+
+// TODO: Add assignedWallet to the response (currently wallet assign function is not implemented)
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const date = searchParams.get("month");
+
+  const [year, monthStr] = date.split("-");
+  const monthNum = parseInt(monthStr);
+  const startDate = new Date(`${year}-${monthStr}-01T00:00:00Z`);
+  const endDate = new Date(new Date(startDate).setMonth(monthNum));
+
+  try {
+    const checkers = await prisma.Agent.findMany({
+      where: { UserRoleId: 3 },
+      select: { AgentId: true, AwsId: true },
+    });
+
+    const checkerMap = new Map(checkers.map((c) => [c.AgentId, c.AwsId]));
+
+    const txAgents = await prisma.TransactionAgent.findMany({
+      orderBy: { LogDate: "desc" },
+      select: {
+        TransactionID: true,
+        AgentID: true,
+        LogDate: true,
+      },
+    });
+
+    const latestAssignment = {};
+    for (const ta of txAgents) {
+      if (!latestAssignment[ta.TransactionID]) {
+        latestAssignment[ta.TransactionID] = ta.AgentID;
+      }
+    }
+
+    const transactions = await prisma.Transactions.findMany({
+      where: {
+        TransactionDate: {
+          gte: startDate,
+          lt: endDate,
+        },
+      },
+      select: {
+        TransactionID: true,
+        TransactionDate: true,
+        PaymentCheckTime: true,
+        PaymentCheck: true,
+      },
+    });
+
+    const grouped = {};
+
+    for (const tx of transactions) {
+      const agentId = latestAssignment[tx.TransactionID];
+      if (!agentId || !checkerMap.has(agentId)) continue;
+
+      if (!grouped[agentId]) {
+        grouped[agentId] = {
+          checkerId: agentId,
+          name: checkerMap.get(agentId),
+          checked: 0,
+          pending: 0,
+          durations: [],
+          under48h: 0,
+          over48h: 0,
+        };
+      }
+
+      const record = grouped[agentId];
+
+      if (tx.PaymentCheck === true && tx.PaymentCheckTime) {
+        record.checked++;
+
+        const duration = dayjs(tx.PaymentCheckTime).diff(
+          dayjs(tx.TransactionDate),
+          "hour",
+          true
+        );
+
+        record.durations.push(duration);
+
+        if (duration <= 48) {
+          record.under48h++;
+        } else {
+          record.over48h++;
+        }
+      } else {
+        record.pending++;
+      }
+    }
+
+    const result = Object.values(grouped).map((checker) => {
+      const totalChecked = checker.checked;
+      const avgTime =
+        totalChecked > 0
+          ? (
+              checker.durations.reduce((sum, t) => sum + t, 0) / totalChecked
+            ).toFixed(2)
+          : null;
+
+      const underPct =
+        totalChecked > 0
+          ? ((checker.under48h / totalChecked) * 100).toFixed(1)
+          : "0.0";
+
+      const overPct =
+        totalChecked > 0
+          ? ((checker.over48h / totalChecked) * 100).toFixed(1)
+          : "0.0";
+
+      return {
+        date: date,
+        checkerId: checker.checkerId,
+        checked: totalChecked,
+        pending: checker.pending,
+        assignedWallet: [],
+        averageTimeHours: avgTime,
+        under48hPercent: `${underPct}%`,
+        over48hPercent: `${overPct}%`,
+      };
+    });
+
+    return NextResponse.json({
+      status: 200,
+      message: "KPI data retrieved successfully",
+      data: result,
+    });
+  } catch (error) {
+    console.error("KPI API error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch KPI data" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
I created new api for Payment Checker KPIs Table. (/api/transactions/checker-kips)
This api will response

`{
    "status": 200,
    "message": "KPI data retrieved successfully",
    "data": [
        {
            "date": "2025-05",
            "checkerId": 7,
            "checked": 23,
            "pending": 7,
            "averageTimeHours": "28.63",
            "under48hPercent": "73.9%",
            "over48hPercent": "26.1%"
        },
        {
            "date": "2025-05",
            "checkerId": 8,
            "checked": 3,
            "pending": 0,
            "averageTimeHours": "117.90",
            "under48hPercent": "0.0%",
            "over48hPercent": "100.0%"
        }
    ]
}`