### PR TITLE
fix: month show in exchange rate page

### DIFF
--- a/src/app/admin-panel/_components/exchangeRate/page.jsx
+++ b/src/app/admin-panel/_components/exchangeRate/page.jsx
@@ -84,10 +84,15 @@ export default function ExchangeRates() {
     </Box>
   );
 
+  const currentDate = new Date();
+  const currentMonthName = currentDate.toLocaleString("default", {
+    month: "long",
+  });
+
   return (
     <Box sx={{ mt: "20px" }}>
       <Typography sx={{ fontSize: "23px", fontWeight: 600 }}>
-        March 2025 Exchange Rates (1 USD = )
+        {currentMonthName} 2025 Exchange Rates (1 USD = )
       </Typography>
 
       <Box sx={{ mt: 1 }}>


### PR DESCRIPTION
## Backlog ID & Title

ID - 230

## Description

current month show in exchange rate page

## Screenshots (Optional)

## Type of Change
* [ ] ✨ New feature
* [X] 🐛 Bug fix
* [ ] 🧹 Code cleanup/refactor
* [ ] 📝 Documentation update
* [ ] 🔧 Build/CI pipeline update
* [ ] ⚠️ Breaking change
